### PR TITLE
修复gst和mpp的layout不同导致rga对目标内存大小计算错误

### DIFF
--- a/gst/rockchipmpp/gstmpp.c
+++ b/gst/rockchipmpp/gstmpp.c
@@ -212,7 +212,7 @@ gst_mpp_rga_info_from_video_info (rga_info_t * info, GstVideoInfo * vinfo)
   GstVideoFormat format = GST_VIDEO_INFO_FORMAT (vinfo);
   guint width = GST_VIDEO_INFO_WIDTH (vinfo);
   guint height = GST_VIDEO_INFO_HEIGHT (vinfo);
-  guint hstride = GST_MPP_VIDEO_INFO_HSTRIDE (vinfo);
+  guint hstride = gst_mpp_get_pixel_stride (vinfo);
   guint vstride = GST_MPP_VIDEO_INFO_VSTRIDE (vinfo);
   RgaSURF_FORMAT rga_format = gst_mpp_gst_format_to_rga_format (format);
 


### PR DESCRIPTION
假如640x480的nv12帧需要转换颜色空间到rgb，因为rga所用的是类似[640, 480, 3]的layout，而gst则认为是应该是[640x3, 480]，然后gst又在这里gst_mpp_set_rga_info，把hstride: 640x3传给了rga的info。

https://github.com/JeffyCN/rockchip_mirrors/blob/b654ce25b062efebc0cb1107acd02cc811aab55a/gst/rockchipmpp/gstmpp.c#L186

` rga_set_rect (&info->rect, 0, 0, width, height, hstride, vstride, rga_format); `

导致rga以为目标内存有[640*3, 480, 3]那么大，也就是申请的内存的3倍大小。所以在gst中用mppvideodec转换到非nv12，nv21之外的颜色空间必然导致rga出错，比如rgb/bgr,rgba/bgra等等

修复办法就是在传给rga之前，gst把hstride除以目标颜色空间的pixel_stride，刚好gst_mpp_get_pixel_stride这个函数就是做这个的